### PR TITLE
Fix event context parameter conversion

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -31,19 +31,23 @@ class Api::V1::EventsController < ApplicationController
       Rails.logger.debug "Skipping offline incarnation event: #{incarnation_id}"
       return
     end
-    
+
+    # Convert ActionController::Parameters to hash to avoid permit issues
+    event_hash = event_data.is_a?(ActionController::Parameters) ? event_data.to_unsafe_h : event_data
+    context_hash = event_hash[:context].is_a?(ActionController::Parameters) ? event_hash[:context].to_unsafe_h : event_hash[:context]
+
     # Find the incarnation
     incarnation = Incarnation.find_by!(incarnation_id: incarnation_id)
-    
+
     # Store the raw event in Rails Event Store
-    event = build_event_from_type(event_data[:type], event_data)
+    event = build_event_from_type(event_hash[:type], event_hash)
     Rails.configuration.event_store.publish(event)
-    
-    # Apply immediate effects
-    incarnation.apply_experience_event(event_data[:type], event_data[:context])
-    
+
+    # Apply immediate effects - pass converted hash
+    incarnation.apply_experience_event(event_hash[:type], context_hash)
+
     # Handle relationship effects
-    handle_relationship_effects(incarnation, event_data)
+    handle_relationship_effects(incarnation, event_hash)
   end
   
   def build_event_from_type(type, data)


### PR DESCRIPTION
## Summary

Fixes the "unable to convert unpermitted parameters to hash" error that occurs when processing combat events.

## Problem

When the events controller receives combat events, the `context` field is an `ActionController::Parameters` object. When this gets passed to `incarnation.apply_experience_event()`, Rails tries to access it like a hash but fails because it's still a Parameters object that needs explicit conversion.

## Solution

Explicitly convert both `event_data` and `context` to hashes using `to_unsafe_h` before processing:

```ruby
event_hash = event_data.is_a?(ActionController::Parameters) ? event_data.to_unsafe_h : event_data
context_hash = event_hash[:context].is_a?(ActionController::Parameters) ? event_hash[:context].to_unsafe_h : event_hash[:context]
```

## Impact

Resolves errors when processing:
- `combat_kill` events
- `combat_death` events  
- Any event with a nested `context` object

## Testing

Deploy and verify that combat events process without "unpermitted parameters" errors in the logs.

🤖 Generated with [Claude Code](https://claude.ai/code)